### PR TITLE
Allow smart pointers as base return types for request handler functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,17 @@ The derived subscriber class will then need to implement one handler function ca
 for the `RequestSubscriber` base class.
 
 Each handler function takes one argument of the given request type, and has a return
-type of either `void` or the type defined in the given request's template parameter
-`RESULT_TYPE`.
+type determined by the request's template parameter `RESULT_TYPE`. For `RESULT_TYPE`
+of `void`, `std::optional<T>`, `std::shared_ptr<T>`, `std::unique_ptr<T>` or a raw
+pointer, return type is the same as `RESULT_TYPE`. For all other cases, the return
+type wraps `RESULT_TYPE` as `std::optional<RESULT_TYPE>`. To clarify:
+
+- If `RESULT_TYPE` == `void`, return type == `void`
+- If `RESULT_TYPE` == `std::optional<T>`, return type == `std::optional<T>`
+- If `RESULT_TYPE` == `std::shared_ptr<T>`, return type == `std::shared_ptr<T>`
+- If `RESULT_TYPE` == `std::unique_ptr<T>`, return type == `std::unique_ptr<T>`
+- If `RESULT_TYPE` == `T*`, return type == `T*`
+- Else, return type == `std::optional<RESULT_TYPE>`
 
 ### Request Dispatcher
 
@@ -130,7 +139,5 @@ Call `request_dispatcher.dispatch(request);` to dispatch a request to be handled
 currently subscribed to the given request type.
 
 Call `auto result = request_dispatcher.dispatch(request);` or similar if you expect this request
-handler function to result in a return type. `auto` == `std::optional<RESULT_TYPE>` where
-`RESULT_TYPE` is the template parameter of the given request type as detailed above. If no object
-is subscribed to a given request type with a non-void return type at the time that the request is
-dispatched, `std::nullopt` is returned.
+handler function to result in a return type. See "Request Subscriber" section above for details
+of the expected return type.

--- a/example/request_demo.cpp
+++ b/example/request_demo.cpp
@@ -31,9 +31,12 @@ struct RequestWithData : public dispatch::Request<> {
 };
 using DoSomethingRequest = dispatch::Request<>;
 struct GiveMeStuffRequest : public dispatch::Request<int> {};
+struct GiveMeStuffIfYouLikeRequest : public dispatch::Request<std::optional<int>> {};
+struct GiveMePointersRequest : public dispatch::Request<std::shared_ptr<int>> {};
+struct GiveMeRawPointersRequest : public dispatch::Request<float*> {};
 
 
-class MySubscriberClass : public dispatch::RequestSubscriber<RequestWithData, DoSomethingRequest, GiveMeStuffRequest>
+class MySubscriberClass : public dispatch::RequestSubscriber<RequestWithData, DoSomethingRequest, GiveMeStuffRequest, GiveMeStuffIfYouLikeRequest, GiveMePointersRequest, GiveMeRawPointersRequest>
 {
 
 public:
@@ -50,6 +53,21 @@ public:
         std::cout << "Handling give me stuff request and returning `7`" << std::endl;
         return 7;
     }
+
+    std::optional<int> handle_request(const GiveMeStuffIfYouLikeRequest& request) override {
+        std::cout << "Didn't feel like handling give me stuff if you like request and returning `std::nullptr`" << std::endl;
+        return std::nullopt;
+    }
+
+    std::shared_ptr<int> handle_request(const GiveMePointersRequest& request) override {
+        std::cout << "Didn't feel like handling give me pointers request and returning `nullptr`" << std::endl;
+        return nullptr;
+    }
+
+    float* handle_request(const GiveMeRawPointersRequest& request) override {
+        std::cout << "Didn't feel like handling give me raw pointers request and returning `nullptr`" << std::endl;
+        return nullptr;
+    }
 };
 
 
@@ -63,36 +81,54 @@ int main()
     RequestWithData request { .data = 67890 };
     DoSomethingRequest do_something_request;
     GiveMeStuffRequest give_me_stuff_request;
+    GiveMeStuffIfYouLikeRequest give_me_stuff_if_you_like_request;
+    GiveMePointersRequest give_me_pointers_request;
+    GiveMeRawPointersRequest give_me_raw_pointers_request;
 
     request_dispatcher.subscribe(&subscriber);
     std::cout << std::endl << "--General request subscription--" << std::endl;
     request_dispatcher.dispatch(request);
     request_dispatcher.dispatch(do_something_request);
     request_dispatcher.dispatch(give_me_stuff_request);
+    request_dispatcher.dispatch(give_me_stuff_if_you_like_request);
+    request_dispatcher.dispatch(give_me_pointers_request);
+    request_dispatcher.dispatch(give_me_raw_pointers_request);
 
     request_dispatcher.unsubscribe(&subscriber);
     std::cout << std::endl << "--General request unsubscription--" << std::endl;
     request_dispatcher.dispatch(request);
     request_dispatcher.dispatch(do_something_request);
     request_dispatcher.dispatch(give_me_stuff_request);
+    request_dispatcher.dispatch(give_me_stuff_if_you_like_request);
+    request_dispatcher.dispatch(give_me_pointers_request);
+    request_dispatcher.dispatch(give_me_raw_pointers_request);
 
-    request_dispatcher.subscribe<RequestWithData, GiveMeStuffRequest>(&subscriber);
-    std::cout << std::endl << "--Specific request `MyRequest` and `GiveMeStuffRequest` subscription--" << std::endl;
+    request_dispatcher.subscribe<RequestWithData, GiveMeStuffRequest, GiveMePointersRequest>(&subscriber);
+    std::cout << std::endl << "--Specific request `MyRequest`, `GiveMeStuffRequest` and `GiveMePointersRequest` subscription--" << std::endl;
     request_dispatcher.dispatch(request);
     request_dispatcher.dispatch(do_something_request);
     request_dispatcher.dispatch(give_me_stuff_request);
+    request_dispatcher.dispatch(give_me_stuff_if_you_like_request);
+    request_dispatcher.dispatch(give_me_pointers_request);
+    request_dispatcher.dispatch(give_me_raw_pointers_request);
 
     request_dispatcher.subscribe<DoSomethingRequest>(&subscriber);
     std::cout << std::endl << "--Specific request `DoSomethingRequest`` subscription--" << std::endl;
     request_dispatcher.dispatch(request);
     request_dispatcher.dispatch(do_something_request);
     request_dispatcher.dispatch(give_me_stuff_request);
+    request_dispatcher.dispatch(give_me_stuff_if_you_like_request);
+    request_dispatcher.dispatch(give_me_pointers_request);
+    request_dispatcher.dispatch(give_me_raw_pointers_request);
 
     request_dispatcher.unsubscribe<RequestWithData>(&subscriber);
     std::cout << std::endl << "--Specific request `Request` unsubscription--" << std::endl;
     request_dispatcher.dispatch(request);
     request_dispatcher.dispatch(do_something_request);
     request_dispatcher.dispatch(give_me_stuff_request);
+    request_dispatcher.dispatch(give_me_stuff_if_you_like_request);
+    request_dispatcher.dispatch(give_me_pointers_request);
+    request_dispatcher.dispatch(give_me_raw_pointers_request);
 
     return 0;
 }

--- a/src/concepts/subscriber_concepts.h
+++ b/src/concepts/subscriber_concepts.h
@@ -21,8 +21,8 @@ constexpr bool _are_unique_types_v_ = (!std::is_same_v<FIRST_TYPE_IN_LIST, REST_
 template<class T>
 constexpr bool _are_unique_types_v_<T> = true;
 
-template<class TYPE_LIST>
-concept _are_unique_types_ = (_are_unique_types_v_<TYPE_LIST>);
+template<class ... TYPE_LIST>
+concept _are_unique_types_ = (_are_unique_types_v_<TYPE_LIST...>);
 
 
 /** Request Return Types Traits */

--- a/src/concepts/subscriber_concepts.h
+++ b/src/concepts/subscriber_concepts.h
@@ -5,6 +5,8 @@
 #pragma once
 
 
+#include <memory>
+#include <optional>
 #include <type_traits>
 
 
@@ -13,14 +15,50 @@ namespace dispatch {
 
 /** Unique Types **/
 
-template<typename FIRST_TYPE_IN_LIST, typename... REST_OF_TYPE_LIST>
+template<class FIRST_TYPE_IN_LIST, class... REST_OF_TYPE_LIST>
 constexpr bool _are_unique_types_v_ = (!std::is_same_v<FIRST_TYPE_IN_LIST, REST_OF_TYPE_LIST> && ...) && _are_unique_types_v_<REST_OF_TYPE_LIST...>;
 
-template<typename T>
+template<class T>
 constexpr bool _are_unique_types_v_<T> = true;
 
-template <class TYPE_LIST>
+template<class TYPE_LIST>
 concept _are_unique_types_ = (_are_unique_types_v_<TYPE_LIST>);
+
+
+/** Request Return Types Traits */
+
+template<class T>
+struct _is_optional_t_ : std::false_type {};
+template<class T>
+struct _is_optional_t_<std::optional<T>> : std::true_type {};
+
+template<class T>
+struct _is_smart_pointer_t_ : std::false_type {};
+template<class T>
+struct _is_smart_pointer_t_<std::shared_ptr<T>> : std::true_type {};
+template<class T>
+struct _is_smart_pointer_t_<std::unique_ptr<T>> : std::true_type {};
+
+template<class T>
+struct _is_smart_wrapper_t_ : std::false_type {};
+template<class T>
+struct _is_smart_wrapper_t_<std::optional<T>> : std::true_type {};
+template<class T>
+struct _is_smart_wrapper_t_<std::shared_ptr<T>> : std::true_type {};
+template<class T>
+struct _is_smart_wrapper_t_<std::unique_ptr<T>> : std::true_type {};
+
+template<class T>
+constexpr bool _is_unwrapped_request_return_type_v_ = (std::is_void<T>::value || std::is_pointer<T>::value || _is_smart_wrapper_t_<T>::value);
+
+
+/** Type Concepts */
+
+template<class T>
+concept _is_optional_ = _is_optional_t_<T>::value;
+
+template<class T>
+concept _is_raw_or_smart_pointer_ = std::is_pointer<T>::value || _is_smart_pointer_t_<T>::value;
 
 
 } // dispatch

--- a/src/event/event_dispatcher.h
+++ b/src/event/event_dispatcher.h
@@ -55,7 +55,7 @@ public:
     }
 
     template<class EVENT_TYPE>
-    void dispatch(const EVENT_TYPE& event)
+    void dispatch(const EVENT_TYPE& event) const
     {
         const auto event_subscribers_iter = _subscriber_map.find(typeid(event));
 

--- a/src/event/event_subscriber.h
+++ b/src/event/event_subscriber.h
@@ -49,7 +49,7 @@ class _SingleEventSubscriber_ : virtual public _EventSubscriberBase_
 };
 
 
-template<_are_unique_types_ ... EVENT_TYPE_LIST>
+template<class ... EVENT_TYPE_LIST> requires _are_unique_types_<EVENT_TYPE_LIST...>
 class EventSubscriber : public _SingleEventSubscriber_<EVENT_TYPE_LIST>...
 {
     friend EventDispatcher;

--- a/src/request/request_dispatcher.h
+++ b/src/request/request_dispatcher.h
@@ -111,6 +111,36 @@ public:
         sub_subscriber->handle_request(request);
     }
 
+    template<_is_optional_ REQUEST_TYPE>
+    auto dispatch(const REQUEST_TYPE& request) -> typename REQUEST_TYPE::_RETURN_TYPE_
+    {
+        const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
+
+        if (request_subscriber_iter == _subscriber_map.end()) {
+            return std::nullopt;
+        }
+
+        const auto& subscriber = request_subscriber_iter->second;
+
+        auto sub_subscriber = dynamic_cast<_SingleRequestSubscriber_<REQUEST_TYPE>*>(subscriber);
+        return sub_subscriber->handle_request(request);
+    }
+
+    template<_is_raw_or_smart_pointer_ REQUEST_TYPE>
+    auto dispatch(const REQUEST_TYPE& request) -> typename REQUEST_TYPE::_RETURN_TYPE_
+    {
+        const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
+
+        if (request_subscriber_iter == _subscriber_map.end()) {
+            return nullptr;
+        }
+
+        const auto& subscriber = request_subscriber_iter->second;
+
+        auto sub_subscriber = dynamic_cast<_SingleRequestSubscriber_<REQUEST_TYPE>*>(subscriber);
+        return sub_subscriber->handle_request(request);
+    }
+
     template<class REQUEST_TYPE>
     auto dispatch(const REQUEST_TYPE& request) -> std::optional<typename REQUEST_TYPE::_RETURN_TYPE_>
     {

--- a/src/request/request_dispatcher.h
+++ b/src/request/request_dispatcher.h
@@ -92,7 +92,7 @@ public:
         const std::vector<std::type_index> _d_request_type_id_list = { typeid(REQUEST_TYPE_LIST)... };
 
         for (auto type_id : _d_request_type_id_list) {
-            _try_subscribe_to_type_id(subscriber, type_id);
+            _unsubscribe_from_type_id(subscriber, type_id);
         }
     }
 
@@ -111,7 +111,7 @@ public:
         sub_subscriber->handle_request(request);
     }
 
-    template<_is_optional_ REQUEST_TYPE>
+    template<class REQUEST_TYPE> requires _is_optional_<typename REQUEST_TYPE::_RETURN_TYPE_>
     auto dispatch(const REQUEST_TYPE& request) const -> typename REQUEST_TYPE::_RETURN_TYPE_
     {
         const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
@@ -126,7 +126,7 @@ public:
         return sub_subscriber->handle_request(request);
     }
 
-    template<_is_raw_or_smart_pointer_ REQUEST_TYPE>
+    template<class REQUEST_TYPE> requires _is_raw_or_smart_pointer_<typename REQUEST_TYPE::_RETURN_TYPE_>
     auto dispatch(const REQUEST_TYPE& request) const -> typename REQUEST_TYPE::_RETURN_TYPE_
     {
         const auto request_subscriber_iter = _subscriber_map.find(typeid(request));

--- a/src/request/request_dispatcher.h
+++ b/src/request/request_dispatcher.h
@@ -97,7 +97,7 @@ public:
     }
 
     template<class REQUEST_TYPE> requires std::is_void<typename REQUEST_TYPE::_RETURN_TYPE_>::value
-    void dispatch(const REQUEST_TYPE& request)
+    void dispatch(const REQUEST_TYPE& request) const
     {
         const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
 
@@ -112,7 +112,7 @@ public:
     }
 
     template<_is_optional_ REQUEST_TYPE>
-    auto dispatch(const REQUEST_TYPE& request) -> typename REQUEST_TYPE::_RETURN_TYPE_
+    auto dispatch(const REQUEST_TYPE& request) const -> typename REQUEST_TYPE::_RETURN_TYPE_
     {
         const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
 
@@ -127,7 +127,7 @@ public:
     }
 
     template<_is_raw_or_smart_pointer_ REQUEST_TYPE>
-    auto dispatch(const REQUEST_TYPE& request) -> typename REQUEST_TYPE::_RETURN_TYPE_
+    auto dispatch(const REQUEST_TYPE& request) const -> typename REQUEST_TYPE::_RETURN_TYPE_
     {
         const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
 
@@ -142,7 +142,7 @@ public:
     }
 
     template<class REQUEST_TYPE>
-    auto dispatch(const REQUEST_TYPE& request) -> std::optional<typename REQUEST_TYPE::_RETURN_TYPE_>
+    auto dispatch(const REQUEST_TYPE& request) const -> std::optional<typename REQUEST_TYPE::_RETURN_TYPE_>
     {
         const auto request_subscriber_iter = _subscriber_map.find(typeid(request));
 

--- a/src/request/request_subscriber.h
+++ b/src/request/request_subscriber.h
@@ -59,7 +59,7 @@ class _SingleRequestSubscriber_ : virtual public _RequestSubscriberBase_
 };
 
 
-template<_are_unique_types_ ... REQUEST_TYPE_LIST>
+template<class ... REQUEST_TYPE_LIST> requires _are_unique_types_<REQUEST_TYPE_LIST...>
 class RequestSubscriber : public _SingleRequestSubscriber_<REQUEST_TYPE_LIST>...
 {
     friend RequestDispatcher;

--- a/src/request/request_subscriber.h
+++ b/src/request/request_subscriber.h
@@ -26,6 +26,7 @@
 
 
 #include <concepts>
+#include <memory>
 #include <optional>
 #include <typeindex>
 #include <vector>
@@ -49,8 +50,10 @@ class _SingleRequestSubscriber_ : virtual public _RequestSubscriberBase_
 {
     friend RequestDispatcher;
 
-    using RETURN_TYPE = typename std::conditional<std::is_void<typename REQUEST_TYPE::_RETURN_TYPE_>::value,
-                                                  void, std::optional<typename REQUEST_TYPE::_RETURN_TYPE_>>::type;
+    using RETURN_TYPE = typename std::conditional<
+            _is_unwrapped_request_return_type_v_<typename REQUEST_TYPE::_RETURN_TYPE_>,
+            typename REQUEST_TYPE::_RETURN_TYPE_,
+            std::optional<typename REQUEST_TYPE::_RETURN_TYPE_>>::type;
 
     virtual RETURN_TYPE handle_request(const REQUEST_TYPE& dispatch) = 0;
 };


### PR DESCRIPTION
Request with `std::shared_ptr`, `std::unique_ptr` values for `_RETURN_TYPE_` do not have the handler function return type wrapped in a `std::optional` and so `nullptr` is returned when no objects are subscribed to the request.

The same is true for requests with `std::optional` values for `_RETURN_TYPE_` for cases where request struct declarations need to be explicit.